### PR TITLE
Added 'extension' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ jade: {
 }
 ```
 
+For custom extension, add:
+```javascript
+jade: {
+  custom_extension: {
+    src: ['path/to/src/*.jade'],
+    dest: 'dest/path/',
+    options: {
+      extension: '.xml',
+    }
+  }
+}
+```
+
 ## Defaults
 
 ```javascript

--- a/example/grunt.js
+++ b/example/grunt.js
@@ -65,6 +65,14 @@ module.exports = function(grunt) {
           node: true,
           dependencies: 'runtime'
         }
+      },
+      custom_extension: {
+        src: ['templates/src/*.jade'],
+        dest: 'templates/custom_extension/',
+        options: {
+          client: false,
+          extension: '.xml'
+        }
       }
     }
   });

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -21,7 +21,8 @@ module.exports = function(grunt) {
     var options = grunt.utils._.extend({
       client: true,
       runtime: true,
-      compileDebug: false
+      compileDebug: false,
+      extension: null
     }, this.data.options);
 
     var wrapper = grunt.utils._.extend({
@@ -37,12 +38,14 @@ module.exports = function(grunt) {
     // Make the dest dir if it doesn't exist
     grunt.file.mkdir(dest);
 
+    var outputExtension = (options.extension !== null)? options.extension
+                                                      : (options.client? '.js' : '.html');
+
     // Loop through all files and write them to files
     files.forEach(function(filepath) {
       var fileExtname = path.extname(filepath)
         , src = grunt.file.read(filepath)
         , outputFilename = path.basename(filepath, fileExtname)
-        , outputExtension = options.client ? '.js' : '.html'
         , outputFilepath = dest + outputFilename + outputExtension
         , compiled = grunt.helper('compile', src, options, wrapper, outputFilename, filepath);
       grunt.file.write(outputFilepath, compiled);


### PR DESCRIPTION
Added an option used to specify the extension of the output file. This is useful when you want to set an extension that is not `.js` or `.html` (`.xml`, for example), or when you want to remove the extension part completely (e.g. when compiling handlebars templates written in jade, s.t. `file.handlebars.jade` becomes `file.handlebars` after it is compiled).

If both the `extension` and `client` options are set, then the specified extension is used.
If the `extension` option is not set, then the extension is determined by the `client` option.
