### PR TITLE
expandFiles has been deprecated

### DIFF
--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -94,7 +94,7 @@ module.exports = function(grunt) {
       // Make the dest dir if it doesn't exist
       grunt.file.mkdir(dest);
 
-      var files = grunt.file.expandFiles(fileObj.src);
+      var files = grunt.file.expand({nonull: true}, fileObj.src);
 
       files.forEach(function(filepath){
         console.log(filepath);


### PR DESCRIPTION
After upgrading to grunt 0.4.0, grunt-jade aborted with this message:

```
Running "jade:web" (jade) task
Warning: Object #<Object> has no method 'expandFiles' Use --force to continue.
Aborted due to warnings.
```

"Removed file.expandFiles and file.expandDirs methods, use the filter option of file.expand instead." - http://gruntjs.com/upgrading-from-0.3-to-0.4

This change fixed the issue and grunt-jade is now working for me on grunt v0.4.0
